### PR TITLE
refactor: extract inline scripts into dedicated source files

### DIFF
--- a/src/_includes/layouts/_anti-flash.ts
+++ b/src/_includes/layouts/_anti-flash.ts
@@ -1,0 +1,13 @@
+/**
+ * Inline script injected into `<head>` before any CSS renders.
+ *
+ * Reads the stored color-scheme preference from `localStorage` and applies it
+ * to the `data-color-scheme` attribute on `<html>` before the browser paints,
+ * preventing a flash of the wrong theme on page load.
+ *
+ * Intentionally minified: this runs synchronously on the critical path, so
+ * every byte matters. It must remain inline — an external script loaded with
+ * `defer` or `async` would arrive too late to suppress the flash.
+ */
+export const ANTI_FLASH_SCRIPT =
+  `(function(){var t=localStorage.getItem("color-scheme");if(t==="light"||t==="dark"){document.documentElement.setAttribute("data-color-scheme",t);}})();`;

--- a/src/_includes/layouts/base.ts
+++ b/src/_includes/layouts/base.ts
@@ -1,36 +1,11 @@
 /** Base HTML layout. Every page and layout chains to this. */
 
+import { ANTI_FLASH_SCRIPT } from "./_anti-flash.ts";
+
 /** Typed helpers used in this layout. */
 type H = {
   attr: (attrs: Record<string, unknown>) => string;
 };
-
-/**
- * Inline script injected into `<head>` before any CSS renders.
- * Reads the stored color-scheme preference and applies it to `:root`
- * to prevent a flash of the wrong theme on page load.
- */
-const antiFlashScript =
-  `(function(){var t=localStorage.getItem("color-scheme");if(t==="light"||t==="dark"){document.documentElement.setAttribute("data-color-scheme",t);}})();`;
-
-/**
- * Inline script that wires up the theme toggle button.
- * Injected at the end of `<body>` so the DOM is available.
- */
-const themeToggleScript = `(function(){
-  var root=document.documentElement;
-  var btn=document.getElementById("theme-toggle");
-  if(!btn)return;
-  function effective(){return root.getAttribute("data-color-scheme")||(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");}
-  function update(t){btn.setAttribute("aria-label",t==="dark"?"Switch to light theme":"Switch to dark theme");}
-  update(effective());
-  btn.addEventListener("click",function(){
-    var next=effective()==="dark"?"light":"dark";
-    root.setAttribute("data-color-scheme",next);
-    localStorage.setItem("color-scheme",next);
-    update(next);
-  });
-})();`;
 
 export default function (
   { title, description, content, url, comp }: Lume.Data,
@@ -51,7 +26,7 @@ export default function (
   }>
     <title>${pageTitle}</title>
     <meta ${attr({ name: "description", content: metaDescription })}>
-    <script>${antiFlashScript}</script>
+    <script>${ANTI_FLASH_SCRIPT}</script>
     <link rel="stylesheet" href="/style.css">
     <link rel="alternate" type="application/rss+xml" title="normco.re" href="/feed.xml">
     <link rel="alternate" type="application/json" title="normco.re JSON feed" href="/feed.json">
@@ -65,7 +40,7 @@ export default function (
       </main>
       ${comp.Footer({})}
     </div>
-    <script>${themeToggleScript}</script>
+    <script src="/theme-toggle.js"></script>
   </body>
 </html>`;
 }

--- a/src/theme-toggle.page.ts
+++ b/src/theme-toggle.page.ts
@@ -1,0 +1,30 @@
+/**
+ * Outputs the theme-toggle client script as `/theme-toggle.js`.
+ *
+ * This script wires up the `#theme-toggle` button: it reads the effective
+ * color scheme (from `data-color-scheme` or the system preference), updates
+ * the button's `aria-label`, and persists the user's choice to `localStorage`
+ * on each click.
+ *
+ * Loaded at the end of `<body>` so the DOM is already available.
+ */
+
+/** Output path in the built site. */
+export const url = "/theme-toggle.js";
+
+export default function (): string {
+  return `(function(){
+  var root=document.documentElement;
+  var btn=document.getElementById("theme-toggle");
+  if(!btn)return;
+  function effective(){return root.getAttribute("data-color-scheme")||(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");}
+  function update(t){btn.setAttribute("aria-label",t==="dark"?"Switch to light theme":"Switch to dark theme");}
+  update(effective());
+  btn.addEventListener("click",function(){
+    var next=effective()==="dark"?"light":"dark";
+    root.setAttribute("data-color-scheme",next);
+    localStorage.setItem("color-scheme",next);
+    update(next);
+  });
+})();`;
+}


### PR DESCRIPTION
Move the two inline scripts from the base layout into their own modules:

- `src/_includes/layouts/_anti-flash.ts`: exports `ANTI_FLASH_SCRIPT`, the minified IIFE that reads `localStorage` and sets `data-color-scheme` on `<html>` before any CSS renders. The string is still embedded inline in `<head>` at build time — an external script loaded with `defer`/`async` would arrive too late to suppress the theme flash.

- `src/theme-toggle.page.ts`: a Lume `.page.ts` asset that outputs `/theme-toggle.js`. The base layout now references it with `<script src="/theme-toggle.js"></script>` instead of inlining the code.

No behaviour changes. `_config.ts` is unchanged: Lume auto-discovers `.page.ts` files, so the new asset is picked up without additional `site.add()` calls.

https://claude.ai/code/session_017RVtmoWq6kNFE75qnUZgKq