### PR TITLE
chore(assets): fingerprint gallery, mobile-tools loader, and pretext probe

### DIFF
--- a/scripts/fingerprint-assets.ts
+++ b/scripts/fingerprint-assets.ts
@@ -27,7 +27,7 @@ const TEXT_EXTENSIONS = new Set([".html", ".xml", ".xsl", ".js", ".css"]);
  * _config/assets.ts, whether they originate from site.add() or site.copy().
  * Service worker files are excluded — they use internal versioning instead.
  */
-const CANONICAL_ASSET_URLS = [
+export const CANONICAL_ASSET_URLS = [
   "/critical/about.css",
   "/critical/archive.css",
   "/critical/home.css",
@@ -37,7 +37,7 @@ const CANONICAL_ASSET_URLS = [
   "/style.css",
   ...FINGERPRINTED_SCRIPT_ASSET_URLS,
 ] as const;
-const SERVICE_WORKER_VERSION_PLACEHOLDER = "__SW_VERSION__";
+export const SERVICE_WORKER_VERSION_PLACEHOLDER = "__SW_VERSION__";
 const SERVICE_WORKER_VERSION_SOURCES = [
   "/sw.js",
 ] as const;
@@ -211,7 +211,9 @@ function parseCliArgs(
   };
 }
 
-async function injectServiceWorkerVersion(rootDir: string): Promise<string> {
+export async function injectServiceWorkerVersion(
+  rootDir: string,
+): Promise<string> {
   const swPath = toOutputPath(rootDir, "/sw.js");
   const swCode = await Deno.readTextFile(swPath);
   const swVersionInputs = await Promise.all(
@@ -239,14 +241,14 @@ async function injectServiceWorkerVersion(rootDir: string): Promise<string> {
   return swVersion;
 }
 
-async function main(): Promise<void> {
-  const { rootDir, showHelp } = parseCliArgs(Deno.args);
+export type FingerprintPipelineResult = {
+  readonly rewrites: ReadonlyArray<readonly [string, string]>;
+  readonly swVersion: string;
+};
 
-  if (showHelp) {
-    console.info(USAGE);
-    return;
-  }
-
+export async function runFingerprintPipeline(
+  rootDir: string,
+): Promise<FingerprintPipelineResult> {
   const rewrites: [string, string][] = [];
 
   for (const sourceUrl of CANONICAL_ASSET_URLS) {
@@ -268,7 +270,20 @@ async function main(): Promise<void> {
   await rewriteUrlsInSiteOutput(rootDir, orderedRewrites);
   const swVersion = await injectServiceWorkerVersion(rootDir);
 
-  for (const [sourceUrl, fingerprintedUrl] of orderedRewrites) {
+  return { rewrites: orderedRewrites, swVersion };
+}
+
+async function main(): Promise<void> {
+  const { rootDir, showHelp } = parseCliArgs(Deno.args);
+
+  if (showHelp) {
+    console.info(USAGE);
+    return;
+  }
+
+  const { rewrites, swVersion } = await runFingerprintPipeline(rootDir);
+
+  for (const [sourceUrl, fingerprintedUrl] of rewrites) {
     console.info(`[fingerprint] ${sourceUrl} -> ${fingerprintedUrl}`);
   }
   console.info(`[fingerprint] service worker graph version -> ${swVersion}`);

--- a/scripts/fingerprint-assets_test.ts
+++ b/scripts/fingerprint-assets_test.ts
@@ -1,0 +1,120 @@
+import { assertNotEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import { withTempDir } from "../test/temp_fs.ts";
+
+import {
+  CANONICAL_ASSET_URLS,
+  runFingerprintPipeline,
+  SERVICE_WORKER_VERSION_PLACEHOLDER,
+} from "./fingerprint-assets.ts";
+import { toOutputPath } from "./_url_paths.ts";
+
+const TARGETED_SCRIPT_URLS = [
+  "/scripts/gallery.js",
+  "/scripts/post-mobile-tools-loader.js",
+  "/scripts/pretext-browser-probe.js",
+] as const;
+
+const SW_FIXTURE = [
+  `// fixture sw.js`,
+  `const SW_VERSION = "${SERVICE_WORKER_VERSION_PLACEHOLDER}";`,
+  `const ASSETS = ${JSON.stringify(CANONICAL_ASSET_URLS, null, 2)};`,
+  `console.log(SW_VERSION, ASSETS);`,
+  ``,
+].join("\n");
+
+async function writeFixtureFile(
+  rootDir: string,
+  urlPath: string,
+  content: string,
+): Promise<void> {
+  const target = toOutputPath(rootDir, urlPath);
+  const targetDir = target.slice(0, target.lastIndexOf("/"));
+  await Deno.mkdir(targetDir, { recursive: true });
+  await Deno.writeTextFile(target, content);
+}
+
+async function captureSwVersionWithBodies(
+  scriptBodies: ReadonlyMap<string, string>,
+): Promise<string> {
+  return await withTempDir("fingerprint-assets-", async (rootDir) => {
+    for (const url of CANONICAL_ASSET_URLS) {
+      const body = scriptBodies.get(url) ?? `/* fixture stub for ${url} */\n`;
+      await writeFixtureFile(rootDir, url, body);
+    }
+
+    await writeFixtureFile(rootDir, "/sw.js", SW_FIXTURE);
+
+    const { swVersion } = await runFingerprintPipeline(rootDir);
+    return swVersion;
+  });
+}
+
+describe("fingerprint-assets cascade invariant", () => {
+  it("propagates body changes from gallery.js into the service worker version", async () => {
+    const baselineVersion = await captureSwVersionWithBodies(
+      new Map([[
+        "/scripts/gallery.js",
+        "/* baseline */ export const v = 1;\n",
+      ]]),
+    );
+    const mutatedVersion = await captureSwVersionWithBodies(
+      new Map([["/scripts/gallery.js", "/* mutated */ export const v = 2;\n"]]),
+    );
+
+    assertNotEquals(baselineVersion, mutatedVersion);
+  });
+
+  it("propagates body changes from post-mobile-tools-loader.js into the service worker version", async () => {
+    const baselineVersion = await captureSwVersionWithBodies(
+      new Map([
+        [
+          "/scripts/post-mobile-tools-loader.js",
+          "/* baseline */ export const v = 1;\n",
+        ],
+      ]),
+    );
+    const mutatedVersion = await captureSwVersionWithBodies(
+      new Map([
+        [
+          "/scripts/post-mobile-tools-loader.js",
+          "/* mutated */ export const v = 2;\n",
+        ],
+      ]),
+    );
+
+    assertNotEquals(baselineVersion, mutatedVersion);
+  });
+
+  it("propagates body changes from pretext-browser-probe.js into the service worker version", async () => {
+    const baselineVersion = await captureSwVersionWithBodies(
+      new Map([
+        [
+          "/scripts/pretext-browser-probe.js",
+          "/* baseline */ export const v = 1;\n",
+        ],
+      ]),
+    );
+    const mutatedVersion = await captureSwVersionWithBodies(
+      new Map([
+        [
+          "/scripts/pretext-browser-probe.js",
+          "/* mutated */ export const v = 2;\n",
+        ],
+      ]),
+    );
+
+    assertNotEquals(baselineVersion, mutatedVersion);
+  });
+
+  it("guards the three targeted scripts against accidentally being dropped from the canonical set", () => {
+    for (const url of TARGETED_SCRIPT_URLS) {
+      if (!CANONICAL_ASSET_URLS.includes(url)) {
+        throw new Error(
+          `Expected ${url} to be fingerprinted (present in CANONICAL_ASSET_URLS).`,
+        );
+      }
+    }
+  });
+});

--- a/src/utils/script-assets.ts
+++ b/src/utils/script-assets.ts
@@ -67,7 +67,7 @@ const SCRIPT_ASSET_DESCRIPTORS = [
   },
   {
     url: "/scripts/gallery.js",
-    fingerprint: false,
+    fingerprint: true,
     precache: false,
   },
   {
@@ -77,7 +77,7 @@ const SCRIPT_ASSET_DESCRIPTORS = [
   },
   {
     url: "/scripts/post-mobile-tools-loader.js",
-    fingerprint: false,
+    fingerprint: true,
     precache: true,
   },
   {
@@ -87,7 +87,7 @@ const SCRIPT_ASSET_DESCRIPTORS = [
   },
   {
     url: "/scripts/pretext-browser-probe.js",
-    fingerprint: false,
+    fingerprint: true,
     precache: false,
   },
   {


### PR DESCRIPTION
## Summary

- Flips `fingerprint: false → true` for the three previously-unversioned scripts in [src/utils/script-assets.ts](src/utils/script-assets.ts): `/scripts/gallery.js`, `/scripts/post-mobile-tools-loader.js`, `/scripts/pretext-browser-probe.js`. `precache` flags are unchanged.
- Adds a cascade invariant test ([scripts/fingerprint-assets_test.ts](scripts/fingerprint-assets_test.ts)) that asserts mutating any of the three script bodies produces a different rewritten `sw.js` hash. Extracts `runFingerprintPipeline()` from `main()` so the test can drive the pipeline directly.

## Why

Audits from Codex and Kimi flagged the three scripts as `cacheFirst` precache targets without a fingerprint, so SW visitors could keep stale copies after a deploy whenever the script body changed without `sw.js` changing. Among the three, `post-mobile-tools-loader.js` is `precache: true`, the highest-risk one. Builds on prior token/policy work in commit b5fd6657.

## Cascade invariant

`fingerprint-assets.ts` rewrites bare URLs (`/scripts/foo.js`) to fingerprinted URLs (`/scripts/foo.<hash>.js`) across `_site/` *before* hashing the rewritten `sw.js` to compute the SW version. The new test verifies the cascade by:
1. Staging two minimal `_site/` fixtures with one of the three target scripts mutated
2. Running the pipeline on each
3. Asserting the resulting SW versions differ

A separate guard test fails if any of the three URLs is dropped from `CANONICAL_ASSET_URLS`.

## Test plan

- [x] `deno task check`
- [x] `deno task test` — 218 passed, 0 failed (was 217)
- [x] `deno task build` — confirms `_site/scripts/{gallery,post-mobile-tools-loader,pretext-browser-probe}.<hash>.js` exist
- [x] `deno task design:guard`
- [x] `deno task locks:check`
- [x] `deno task validate-contracts`
- [x] HTML references in `_site/` rewritten to fingerprinted URLs
- [x] Self-querySelector in `post-mobile-tools-loader.js` correctly rewritten in `_site/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)