### PR TITLE
feat(breakpoints): consolidate layout breakpoints under shared TS source

### DIFF
--- a/scripts/design-token-guard.ts
+++ b/scripts/design-token-guard.ts
@@ -2,6 +2,19 @@ import { parseArgs } from "@std/cli";
 import { walk } from "@std/fs";
 import { join, relative } from "@std/path";
 import { createUsageError, hasHelpFlag, lineNumberAt } from "./_shared.ts";
+import {
+  ABOUT_PICTOGRAM_TABLET_MAX_WIDTH,
+  FEATURE_RAIL_BREAKPOINT,
+  GALLERY_FOUR_COLUMN_BREAKPOINT,
+  GALLERY_THREE_COLUMN_BREAKPOINT,
+  GALLERY_TWO_COLUMN_MAX_WIDTH,
+  HEADER_NAV_BREAKPOINT,
+  HEADER_NAV_MAX_WIDTH,
+  MOBILE_VIEWPORT_MAX_WIDTH,
+  PAGEHEAD_CONTEXT_BREAKPOINT,
+  POST_MOBILE_TOOLS_MAX_WIDTH,
+  STORY_GRID_TWO_COLUMN_BREAKPOINT,
+} from "../src/utils/layout-breakpoints.ts";
 
 export type StyleSource = {
   readonly filePath: string;
@@ -125,6 +138,59 @@ function ruleAllowsFile(rule: GuardRule, filePath: string): boolean {
   ) ?? false;
 }
 
+const ALLOWED_BREAKPOINT_VALUES: ReadonlySet<string> = new Set([
+  ABOUT_PICTOGRAM_TABLET_MAX_WIDTH,
+  FEATURE_RAIL_BREAKPOINT,
+  GALLERY_FOUR_COLUMN_BREAKPOINT,
+  GALLERY_THREE_COLUMN_BREAKPOINT,
+  GALLERY_TWO_COLUMN_MAX_WIDTH,
+  HEADER_NAV_BREAKPOINT,
+  HEADER_NAV_MAX_WIDTH,
+  MOBILE_VIEWPORT_MAX_WIDTH,
+  PAGEHEAD_CONTEXT_BREAKPOINT,
+  POST_MOBILE_TOOLS_MAX_WIDTH,
+  STORY_GRID_TWO_COLUMN_BREAKPOINT,
+]);
+
+const BREAKPOINT_RULE_HEAD_PATTERN = /@(?:media|container)\b[^{]*/g;
+const BREAKPOINT_FEATURE_PATTERN =
+  /\b(?:min|max)-(?:width|height):\s*([0-9.]+rem)/g;
+const BREAKPOINT_GUARD_RULE_NAME = "unregistered-breakpoint-literal";
+const BREAKPOINT_GUARD_MESSAGE =
+  "Use one of the breakpoint constants from `src/utils/layout-breakpoints.ts` " +
+  "(or extend that module if a new semantic threshold is required).";
+
+function scanBreakpointLiterals(
+  styleSource: StyleSource,
+): ReadonlyArray<DesignTokenGuardIssue> {
+  const issues: DesignTokenGuardIssue[] = [];
+
+  for (
+    const headMatch of styleSource.source.matchAll(BREAKPOINT_RULE_HEAD_PATTERN)
+  ) {
+    const headStart = headMatch.index ?? 0;
+    const headText = headMatch[0];
+
+    for (const featureMatch of headText.matchAll(BREAKPOINT_FEATURE_PATTERN)) {
+      const value = featureMatch[1];
+      if (value === undefined || ALLOWED_BREAKPOINT_VALUES.has(value)) {
+        continue;
+      }
+
+      const featureStart = headStart + (featureMatch.index ?? 0);
+      issues.push({
+        filePath: styleSource.filePath,
+        line: lineNumberAt(styleSource.source, featureStart),
+        rule: BREAKPOINT_GUARD_RULE_NAME,
+        message: BREAKPOINT_GUARD_MESSAGE,
+        match: featureMatch[0],
+      });
+    }
+  }
+
+  return issues;
+}
+
 export function scanStyleSources(
   styleSources: ReadonlyArray<StyleSource>,
 ): ReadonlyArray<DesignTokenGuardIssue> {
@@ -147,6 +213,8 @@ export function scanStyleSources(
         });
       }
     }
+
+    issues.push(...scanBreakpointLiterals(styleSource));
   }
 
   return issues.sort((left, right) =>

--- a/src/styles/blog-antd.css
+++ b/src/styles/blog-antd.css
@@ -2007,7 +2007,7 @@
     color: var(--ph-color-accent-emphasis);
   }
 
-  @media (max-width: 63.99rem) {
+  @media (max-width: 63.999rem) {
     .blog-antd-page--archive {
       padding-block-end: calc(env(safe-area-inset-bottom) + var(--ph-space-7));
     }
@@ -2237,7 +2237,7 @@
     }
   }
 
-  @media (min-width: 48rem) and (max-width: 71.99rem) {
+  @media (min-width: 48rem) and (max-width: 71.999rem) {
     .blog-antd-gallery-fallback {
       columns: 2;
     }

--- a/src/utils/layout-breakpoints.ts
+++ b/src/utils/layout-breakpoints.ts
@@ -2,7 +2,12 @@ export const PAGEHEAD_CONTEXT_BREAKPOINT = "52rem";
 export const STORY_GRID_TWO_COLUMN_BREAKPOINT = "48rem";
 export const STORY_GRID_TWO_COLUMN_MEDIA_QUERY =
   `(min-width: ${STORY_GRID_TWO_COLUMN_BREAKPOINT})`;
+export const STORY_GRID_TWO_COLUMN_CONTAINER_QUERY =
+  `(min-width: ${STORY_GRID_TWO_COLUMN_BREAKPOINT})`;
 export const HEADER_NAV_BREAKPOINT = "64rem";
+// Complement of HEADER_NAV_BREAKPOINT used by the archive layout to relax
+// padding and switch the sticky nav presentation when the header collapses.
+export const HEADER_NAV_MAX_WIDTH = "63.999rem";
 export const FEATURE_RAIL_BREAKPOINT = "66rem";
 export const POST_RAIL_BREAKPOINT = FEATURE_RAIL_BREAKPOINT;
 // Keep the post mobile tools query on the classic max-width syntax so Safari
@@ -10,3 +15,23 @@ export const POST_RAIL_BREAKPOINT = FEATURE_RAIL_BREAKPOINT;
 export const POST_MOBILE_TOOLS_MAX_WIDTH = "65.99rem";
 export const POST_MOBILE_TOOLS_MEDIA_QUERY =
   `(max-width: ${POST_MOBILE_TOOLS_MAX_WIDTH})`;
+// Shared mobile-viewport threshold consumed by the footer column stack, the
+// header drawer panel, the about contact toggletip → modal flip, and the
+// header-client mobile panel runtime. Keep aligned with both CSS literals and
+// the JS string constants.
+export const MOBILE_VIEWPORT_MAX_WIDTH = "47.999rem";
+export const MOBILE_VIEWPORT_MEDIA_QUERY =
+  `(max-width: ${MOBILE_VIEWPORT_MAX_WIDTH})`;
+// Gallery column escalation:
+//   < 48rem            → 1 column (implicit)
+//   48rem  – 71.999rem → 2 columns (GALLERY_TWO_COLUMN_MAX_WIDTH)
+//   72rem  – 89.999rem → 3 columns (GALLERY_THREE_COLUMN_BREAKPOINT)
+//   90rem +            → 4 columns (GALLERY_FOUR_COLUMN_BREAKPOINT)
+// The 72rem and 90rem breakpoints also gate the archive nav layout switch.
+export const GALLERY_TWO_COLUMN_MAX_WIDTH = "71.999rem";
+export const GALLERY_THREE_COLUMN_BREAKPOINT = "72rem";
+export const GALLERY_FOUR_COLUMN_BREAKPOINT = "90rem";
+// Tablet range for the about pictogram frame. Pairs with
+// STORY_GRID_TWO_COLUMN_BREAKPOINT (`48rem` min) to bound the medium-width
+// pictogram layout.
+export const ABOUT_PICTOGRAM_TABLET_MAX_WIDTH = "75.999rem";

--- a/src/utils/layout-breakpoints_test.ts
+++ b/src/utils/layout-breakpoints_test.ts
@@ -7,18 +7,36 @@ import { describe, it } from "@std/testing/bdd";
 import blogAntdStyles from "../styles/blog-antd.css" with { type: "text" };
 import layoutStyles from "../styles/layout.css" with { type: "text" };
 import postStyles from "../styles/components/post.css" with { type: "text" };
+import aboutStyles from "../styles/components/about.css" with { type: "text" };
+import headerStyles from "../styles/components/header.css" with {
+  type: "text",
+};
 import postMobileToolsScript from "../scripts/post-mobile-tools.js" with {
+  type: "text",
+};
+import aboutContactToggletipsScript from "../scripts/about-contact-toggletips.js" with {
+  type: "text",
+};
+import headerClientInitScript from "../scripts/header-client/init.js" with {
   type: "text",
 };
 
 import {
+  ABOUT_PICTOGRAM_TABLET_MAX_WIDTH,
   FEATURE_RAIL_BREAKPOINT,
+  GALLERY_FOUR_COLUMN_BREAKPOINT,
+  GALLERY_THREE_COLUMN_BREAKPOINT,
+  GALLERY_TWO_COLUMN_MAX_WIDTH,
   HEADER_NAV_BREAKPOINT,
+  HEADER_NAV_MAX_WIDTH,
+  MOBILE_VIEWPORT_MAX_WIDTH,
+  MOBILE_VIEWPORT_MEDIA_QUERY,
   PAGEHEAD_CONTEXT_BREAKPOINT,
   POST_MOBILE_TOOLS_MAX_WIDTH,
   POST_MOBILE_TOOLS_MEDIA_QUERY,
   POST_RAIL_BREAKPOINT,
   STORY_GRID_TWO_COLUMN_BREAKPOINT,
+  STORY_GRID_TWO_COLUMN_CONTAINER_QUERY,
   STORY_GRID_TWO_COLUMN_MEDIA_QUERY,
 } from "./layout-breakpoints.ts";
 
@@ -35,12 +53,24 @@ describe("layout breakpoints", () => {
       STORY_GRID_TWO_COLUMN_MEDIA_QUERY,
       `(min-width: ${STORY_GRID_TWO_COLUMN_BREAKPOINT})`,
     );
+    assertEquals(
+      STORY_GRID_TWO_COLUMN_CONTAINER_QUERY,
+      `(min-width: ${STORY_GRID_TWO_COLUMN_BREAKPOINT})`,
+    );
+    assertEquals(
+      MOBILE_VIEWPORT_MEDIA_QUERY,
+      `(max-width: ${MOBILE_VIEWPORT_MAX_WIDTH})`,
+    );
   });
 
   it("keeps layout CSS and the mobile tools script aligned with the shared values", () => {
     assertStringIncludes(
       blogAntdStyles,
       `@media ${STORY_GRID_TWO_COLUMN_MEDIA_QUERY}`,
+    );
+    assertStringIncludes(
+      blogAntdStyles,
+      `@container ${STORY_GRID_TWO_COLUMN_CONTAINER_QUERY}`,
     );
     assertStringIncludes(
       layoutStyles,
@@ -65,6 +95,61 @@ describe("layout breakpoints", () => {
     assertStringIncludes(
       postMobileToolsScript,
       "const MOBILE_MEDIA_QUERY = `(max-width: ${POST_MOBILE_TOOLS_MAX_WIDTH})`;",
+    );
+  });
+
+  it("aligns the archive layout max-width with the shared header-nav threshold", () => {
+    assertStringIncludes(
+      blogAntdStyles,
+      `@media (max-width: ${HEADER_NAV_MAX_WIDTH})`,
+    );
+  });
+
+  it("aligns the gallery column escalation with the shared gallery thresholds", () => {
+    assertStringIncludes(
+      blogAntdStyles,
+      `@media (min-width: ${GALLERY_THREE_COLUMN_BREAKPOINT})`,
+    );
+    assertStringIncludes(
+      blogAntdStyles,
+      `@media (min-width: ${GALLERY_FOUR_COLUMN_BREAKPOINT})`,
+    );
+    assertStringIncludes(
+      blogAntdStyles,
+      `@media (min-width: ${STORY_GRID_TWO_COLUMN_BREAKPOINT}) and (max-width: ${GALLERY_TWO_COLUMN_MAX_WIDTH})`,
+    );
+  });
+
+  it("aligns the about pictogram tablet range with the shared bounds", () => {
+    assertStringIncludes(
+      aboutStyles,
+      `@media (min-width: ${STORY_GRID_TWO_COLUMN_BREAKPOINT}) and (max-width: ${ABOUT_PICTOGRAM_TABLET_MAX_WIDTH})`,
+    );
+  });
+
+  it("aligns mobile-viewport CSS surfaces with the shared mobile threshold", () => {
+    assertStringIncludes(
+      layoutStyles,
+      `@media ${MOBILE_VIEWPORT_MEDIA_QUERY}`,
+    );
+    assertStringIncludes(
+      aboutStyles,
+      `@media ${MOBILE_VIEWPORT_MEDIA_QUERY}`,
+    );
+    assertStringIncludes(
+      headerStyles,
+      `@media ${MOBILE_VIEWPORT_MEDIA_QUERY}`,
+    );
+  });
+
+  it("aligns the JS mobile-viewport literals with the shared TS constant", () => {
+    assertStringIncludes(
+      aboutContactToggletipsScript,
+      `const MOBILE_MEDIA_QUERY = "${MOBILE_VIEWPORT_MEDIA_QUERY}";`,
+    );
+    assertStringIncludes(
+      headerClientInitScript,
+      `const MOBILE_PANEL_MEDIA_QUERY = "${MOBILE_VIEWPORT_MEDIA_QUERY}";`,
     );
   });
 });


### PR DESCRIPTION
## Summary

Extends [src/utils/layout-breakpoints.ts](src/utils/layout-breakpoints.ts) with the seven semantic constants that were missing from the shared TS source-of-truth, normalizes two odd `.99` values, and adds a reverse guard inside [scripts/design-token-guard.ts](scripts/design-token-guard.ts) so future drift fails CI.

## Audit findings

CSS inventory across `src/styles/**/*.css`:

| Value | Type | File(s) | Status |
|---|---|---|---|
| `47.999rem` | max @media | layout, about, header + 2 JS files | **new** `MOBILE_VIEWPORT_MAX_WIDTH` |
| `48rem` | min @media + @container | blog-antd, about | reuses `STORY_GRID_TWO_COLUMN_BREAKPOINT` |
| `52rem` | min @container | layout | reuses `PAGEHEAD_CONTEXT_BREAKPOINT` |
| `63.99rem` → `63.999rem` | max @media | blog-antd | **new + normalized** `HEADER_NAV_MAX_WIDTH` |
| `64rem` | min @media | layout | reuses `HEADER_NAV_BREAKPOINT` |
| `65.99rem` | max @media | post | reuses `POST_MOBILE_TOOLS_MAX_WIDTH` (Safari-stable, kept) |
| `66rem` | min @container | layout | reuses `FEATURE_RAIL_BREAKPOINT` |
| `71.99rem` → `71.999rem` | max @media | blog-antd | **new + normalized** `GALLERY_TWO_COLUMN_MAX_WIDTH` |
| `72rem` | min @media | blog-antd | **new** `GALLERY_THREE_COLUMN_BREAKPOINT` |
| `75.999rem` | max @media | about | **new** `ABOUT_PICTOGRAM_TABLET_MAX_WIDTH` |
| `90rem` | min @media | blog-antd | **new** `GALLERY_FOUR_COLUMN_BREAKPOINT` |

## Decisions

- **Naming stays semantic-by-purpose** (no abstract `sm/md/lg/xl`). Each new constant references either the surface it gates (`HEADER_NAV_MAX_WIDTH`, `ABOUT_PICTOGRAM_TABLET_MAX_WIDTH`) or the gallery column escalation it drives.
- **Normalized `63.99` → `63.999rem` and `71.99` → `71.999rem`** in `blog-antd.css`. The pixel difference (≤0.16px @ 16px root) is imperceptible.
- **Kept `65.99rem`** for `POST_MOBILE_TOOLS_MAX_WIDTH` per the existing Safari-stability comment in the module (lines 13-15).
- **Added `STORY_GRID_TWO_COLUMN_CONTAINER_QUERY`** as a sibling of `STORY_GRID_TWO_COLUMN_MEDIA_QUERY` so the @container usage in `blog-antd.css:2246` is asserted explicitly (same value, different gate).
- **Mobile JS literals** (`MOBILE_MEDIA_QUERY` in `about-contact-toggletips.js`, `MOBILE_PANEL_MEDIA_QUERY` in `header-client/init.js`) are now alignment-checked against `MOBILE_VIEWPORT_MEDIA_QUERY` in [layout-breakpoints_test.ts](src/utils/layout-breakpoints_test.ts), same pattern the test already used for `POST_MOBILE_TOOLS_MAX_WIDTH`.

## Reverse guard

[scripts/design-token-guard.ts](scripts/design-token-guard.ts) now scans every `@media` / `@container` rule head in `src/styles/**/*.css` and asserts each `(min|max)-(width|height)` literal matches one of the eleven exported constants. The allowed set is built directly from the TS imports — extending `layout-breakpoints.ts` is the single point of change. No allowlist needed: every literal in the tracked CSS already maps to a constant after this PR.

## Test plan

- [x] `deno task check`
- [x] `deno task test` — 218 passed (722 steps, was 715 before — 7 alignment assertions added across the breakpoint surfaces)
- [x] `deno task build`
- [x] `deno task design:guard` — confirms the new reverse rule has zero violations on tracked CSS
- [x] `deno task locks:check`
- [x] `deno task validate-contracts`
- [x] `deno lint`
- [x] No abstract `sm/md/lg/xl` naming introduced
- [x] No `src/styles/_breakpoints.ts` parallel source created
- [x] No CSS preprocessor / generated file added

🤖 Generated with [Claude Code](https://claude.com/claude-code)